### PR TITLE
Solved basein/baseout recursion issue, issue #4

### DIFF
--- a/def/struct_type.go
+++ b/def/struct_type.go
@@ -50,6 +50,8 @@ func (t *structType) Resolve(tr TypeRegistry, vr ValueRegistry) *IncludeSet {
 		return NewIncludeSet()
 	}
 
+	t.isResolved = true // Moved here from end of function as part of issue #4 fix
+
 	if t.publicName == "!ignore" {
 		t.isResolved = true
 		return NewIncludeSet()
@@ -108,15 +110,20 @@ func (t *structType) Resolve(tr TypeRegistry, vr ValueRegistry) *IncludeSet {
 
 	rb.ResolvedTypes[t.registryName] = t
 
-	t.isResolved = true
 	return rb
 }
 
 func (t *structType) IsIdenticalPublicAndInternal() bool {
 	for _, m := range t.members {
+		// part of fix for issue #4
+		if asPointerType, isPointer := m.resolvedType.(*pointerType); isPointer && asPointerType.resolvedPointsAtType == t {
+			continue
+		}
+
 		if !m.IsIdenticalPublicAndInternal() {
 			return false
 		}
+
 	}
 	return true
 }

--- a/exceptions.json
+++ b/exceptions.json
@@ -315,14 +315,6 @@
     },
 
     "struct": {
-        "VkBaseInStructure": {
-            "publicName": "!ignore",
-            "!comment": "Causes a stack overflow in resolution by recursive self-referencing. Declares pNext, formally part of the API, but never actually used anywhere else."
-        },
-        "VkBaseOutStructure": {
-            "publicName": "!ignore",
-            "!comment": "See VkBaseInStructure"
-        },
         "VkDescriptorSetLayoutBinding": {
             "forceIncludeMember": "descriptorCount",
             "forceIncludeComment": "descriptorCount references an array field in the XML, but that field might be null and then descriptor count has a different meaning. See the man pages/spec."


### PR DESCRIPTION
Bug was related to checking self-referencing pointer members in VkBaseOutStructure when calling IsIdenticalInternalAndExternal(). Same recursion bug affected VkBaseInStructure, both types removed from exceptions.jsoin