### PR TITLE
Internal conv. of vk-populated vals. Fixes #23

### DIFF
--- a/def/pointer_type.go
+++ b/def/pointer_type.go
@@ -81,6 +81,7 @@ func (t *pointerType) TranslateToInternal(inputVar string) string {
 	} else if t.resolvedPointsAtType.IsIdenticalPublicAndInternal() {
 		return inputVar
 	} else if t.resolvedPointsAtType.Category() == CatStruct || t.resolvedPointsAtType.Category() == CatUnion {
+		// This overrides the normal struct TranslateToInternal, to avoid uneccssary dereferencing and addressing a new pointer
 		return fmt.Sprintf("%s.Vulkanize()", inputVar)
 	} else {
 		return fmt.Sprintf("(%s)(%s)", t.InternalName(), t.resolvedPointsAtType.TranslateToInternal(inputVar))


### PR DESCRIPTION
Fixes #23; required slightly different handling of struct/union vs other types. Related issue found and addressed with Bool32 pointer in GetPhysicalDeviceSurfaceSupportKHR.