### PR TITLE
Block enum from using build tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 func init() {
 	flag.StringVar(&inFileName, "inFile", "vk.xml", "Vulkan XML registry file to read")
 	flag.StringVar(&outDirName, "outDir", "vk", "Directory to write go-vk output to")
-	flag.StringVar(&platformTargets, "platform", "win32", "Comma-separated list of platforms to generate for")
+	flag.StringVar(&platformTargets, "platform", "win32,macos,metal", "Comma-separated list of platforms to generate for; this looks at the Vulkan name, not the GOOS name for the platform")
 
 	flag.Parse()
 
@@ -201,7 +201,7 @@ func printCategory(tc def.TypeCategory, fc *feat.Feature, platform *feat.Platfor
 	f, _ := os.Create(outpath)
 	// explicit f.Close() below; not deferred because the file must be written to disk before goimports is run
 
-	if platform != nil && platform.GoBuildTag != "" {
+	if platform != nil && platform.GoBuildTag != "" && tc != def.CatEnum {
 		fmt.Fprintf(f, "//go:build %s\n", platform.GoBuildTag)
 	}
 


### PR DESCRIPTION
Fixes #37 

Platform specific enum values will now be accessible on all platforms. This fixes an issue with generating String() methods. While stringer allows specification of -tags to include other platforms, you would still get compile errors because the underlying const value is hidden by the build tag.

This does not affect commands, structs, extensions, etc. All other types are still guarded with go:build if specified as a platform-specific type in vk.xml

This PR also updates the default generated platforms to include macos and metal