### PR TITLE
Bugfix/20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ vk/
 
 vk-gen
 vk-gen.exe
-vk.xml
+*.xml
 
 .vscode/
 .DS_Store

--- a/def/base_type.go
+++ b/def/base_type.go
@@ -91,8 +91,10 @@ func (t *baseType) PrintTranslateToInternal(w io.Writer, inputVar, outputVar str
 	}
 }
 
-func ReadBaseTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//types/type[@category='basetype']") {
+func ReadBaseTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='basetype' and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
 		newType := NewBaseTypeFromXML(node)
 		if tr[newType.RegistryName()] != nil {
 			logrus.WithField("registry name", newType.RegistryName()).Warn("Overwriting base type in registry")

--- a/def/bitmask_type.go
+++ b/def/bitmask_type.go
@@ -49,8 +49,10 @@ func (t *bitmaskType) PrintPublicDeclaration(w io.Writer) {
 	}
 }
 
-func ReadBitmaskTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//type[@category='bitmask']") {
+func ReadBitmaskTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='bitmask' and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
 		newType := NewBitmaskTypeFromXML(node)
 		if tr[newType.RegistryName()] != nil {
 			logrus.WithField("registry name", newType.RegistryName()).Warn("Overwriting bitmask type in registry")

--- a/def/define_type.go
+++ b/def/define_type.go
@@ -56,8 +56,9 @@ func (t *defineType) PrintPublicDeclaration(w io.Writer) {
 	}
 }
 
-func ReadDefineTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//types/type[@category='define']") {
+func ReadDefineTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='define' and (@api='%s' or not(@api))]", api)
+	for _, node := range xmlquery.Find(doc, queryString) {
 		newType := NewDefineTypeFromXML(node)
 		if tr[newType.RegistryName()] != nil {
 			logrus.WithField("registry name", newType.RegistryName()).

--- a/def/enum_type.go
+++ b/def/enum_type.go
@@ -59,8 +59,10 @@ func (t *enumType) PrintPublicDeclaration(w io.Writer) {
 	}
 }
 
-func ReadEnumTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//type[@category='enum']") {
+func ReadEnumTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='enum' and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
 		newType := NewEnumTypeFromXML(node)
 		if tr[newType.RegistryName()] != nil {
 			logrus.WithField("registry name", newType.RegistryName()).Warn("Overwriting enum type in registry")

--- a/def/external_type.go
+++ b/def/external_type.go
@@ -39,8 +39,10 @@ func (t *externalType) TranslateToInternal(inputVar string) string {
 	return t.genericType.TranslateToInternal(inputVar)
 }
 
-func ReadExternalTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//types/type[not(@category)]") {
+func ReadExternalTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[not(@category) and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
 		typ := NewExternalTypeFromXML(node)
 		if tr[typ.RegistryName()] != nil {
 			logrus.WithField("registry name", typ.RegistryName()).Warn("Overwriting external type in registry")

--- a/def/handle_type.go
+++ b/def/handle_type.go
@@ -43,8 +43,10 @@ func (t *handleType) PrintPublicDeclaration(w io.Writer) {
 	}
 }
 
-func ReadHandleTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//type[@category='handle']") {
+func ReadHandleTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='handle' and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
 		newType := NewHandleTypeFromXML(node)
 		if tr[newType.RegistryName()] != nil {
 			logrus.WithField("registry name", newType.RegistryName()).Warn("Overwriting handle type in registry")

--- a/def/include_type.go
+++ b/def/include_type.go
@@ -1,6 +1,8 @@
 package def
 
 import (
+	"fmt"
+
 	"github.com/antchfx/xmlquery"
 	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -34,8 +36,10 @@ func (t *includeType) Resolve(tr TypeRegistry, vr ValueRegistry) *IncludeSet {
 	return rval
 }
 
-func ReadIncludeTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//types/type[@category='include']") {
+func ReadIncludeTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, _ ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='include' and (@api='%s' or @api='')]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
 		typ := NewIncludeTypeFromXML(node)
 		if tr[typ.RegistryName()] != nil {
 			logrus.WithField("registry name", typ.RegistryName()).Warn("Overwriting include type in registry")

--- a/def/registry_base.go
+++ b/def/registry_base.go
@@ -39,7 +39,7 @@ const (
 	CatMaximum
 )
 
-type fnReadFromXML func(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry)
+type fnReadFromXML func(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry, api string)
 type fnReadFromJSON func(exceptions gjson.Result, tr TypeRegistry, vr ValueRegistry)
 
 func (c TypeCategory) ReadFns() (fnReadFromXML, fnReadFromJSON) {

--- a/def/struct_type.go
+++ b/def/struct_type.go
@@ -422,20 +422,23 @@ func (m *structMember) PrintGoifyContent(preamble, structDecl, epilogue io.Write
 	}
 }
 
-func ReadStructTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//type[@category='struct']") {
-		s := newStructTypeFromXML(node)
+func ReadStructTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='struct' and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
+		s := newStructTypeFromXML(node, api)
 		tr[s.RegistryName()] = s
 	}
 }
 
-func newStructTypeFromXML(node *xmlquery.Node) *structType {
+func newStructTypeFromXML(node *xmlquery.Node, api string) *structType {
 	rval := structType{}
 
 	rval.registryName = node.SelectAttr("name")
 	rval.isReturnedOnly = node.SelectAttr("returnedonly") == "true"
 
-	for _, mNode := range xmlquery.Find(node, "member") {
+	queryString := fmt.Sprintf("member[@api='%s' or not(@api)]", api)
+	for _, mNode := range xmlquery.Find(node, queryString) {
 		rval.members = append(rval.members, newStructMemberFromXML(mNode))
 	}
 

--- a/def/union_type.go
+++ b/def/union_type.go
@@ -130,20 +130,23 @@ func (t *unionType) TranslateToInternal(inputVar string) string {
 	}
 }
 
-func ReadUnionTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry) {
-	for _, node := range xmlquery.Find(doc, "//type[@category='union']") {
-		s := newUnionTypeFromXML(node)
+func ReadUnionTypesFromXML(doc *xmlquery.Node, tr TypeRegistry, vr ValueRegistry, api string) {
+	queryString := fmt.Sprintf("//types/type[@category='union' and (@api='%s' or not(@api))]", api)
+
+	for _, node := range xmlquery.Find(doc, queryString) {
+		s := newUnionTypeFromXML(node, api)
 		tr[s.RegistryName()] = s
 	}
 }
 
-func newUnionTypeFromXML(node *xmlquery.Node) *unionType {
+func newUnionTypeFromXML(node *xmlquery.Node, api string) *unionType {
 	rval := unionType{}
 
 	rval.registryName = node.SelectAttr("name")
 	rval.isReturnedOnly = node.SelectAttr("returnedonly") == "true"
 
-	for _, mNode := range xmlquery.Find(node, "member") {
+	queryString := fmt.Sprintf("member[@api='%s' or not(@api)]", api)
+	for _, mNode := range xmlquery.Find(node, queryString) {
 		rval.members = append(rval.members, newStructMemberFromXML(mNode))
 	}
 

--- a/exceptions.json
+++ b/exceptions.json
@@ -314,6 +314,25 @@
         },
         "PFN_vkGetInstanceProcAddrLUNARG": {
             "underlyingTypeName": "!pointer"
+        },
+
+        "MTLDevice_id": {
+            "underlyingTypeName": "!pointer"
+        },
+        "MTLCommandQueue_id": {
+            "underlyingTypeName": "!pointer"
+        },
+        "MTLBuffer_id": {
+            "underlyingTypeName": "!pointer"
+        },
+        "MTLTexture_id": {
+            "underlyingTypeName": "!pointer"
+        },
+        "MTLSharedEvent_id": {
+            "underlyingTypeName": "!pointer"
+        },
+        "IOSurfaceRef": {
+            "underlyingTypeName": "!pointer"
         }
     },
 


### PR DESCRIPTION
Adds support for a new command line flag "api", default value is "vulkan". 1.3.242 introduced the new vulkansc (safety critical) api to the XML, which caused duplicate definitions of struct members, data types, command parameters, etc.

Fixes #20 - Duplicate struct members due to new vulkansc api

Also fixes #40 - Exceptions for new Metal types needed for new mac platform commands/structs