### PR TITLE
Fix enum constants

### DIFF
--- a/def/enum_value.go
+++ b/def/enum_value.go
@@ -23,6 +23,9 @@ func (v *enumValue) ValueString() string {
 	if v.IsAlias() {
 		return v.resolvedAliasValue.PublicName()
 	} else {
+		if v.bitposString != "" {
+			return fmt.Sprintf("1 << %s", v.bitposString)
+		}
 		if v.extNumber != 0 {
 			tmp := (1000000000 + (v.extNumber-1)*1000 + v.offset) * v.direction
 			return strconv.Itoa(tmp)
@@ -153,6 +156,7 @@ func NewEnumValueFromXML(td TypeDefiner, elt *xmlquery.Node) *enumValue {
 		rval.aliasValueName = alias
 	}
 	rval.comment = elt.SelectAttr("comment")
+	rval.bitposString = elt.SelectAttr("bitpos")
 
 	if rval.underlyingTypeName = elt.SelectAttr("extends"); rval.underlyingTypeName != "" {
 		var err error


### PR DESCRIPTION
A great number of enum constants have wrong values, some examples:
- https://github.com/bbredesen/go-vk/blob/1.3-main/enum.go#L352
- https://github.com/bbredesen/go-vk/blob/1.3-main/enum.go#L397
- https://github.com/bbredesen/go-vk/blob/1.3-main/enum.go#L814

After generating enum.go with the fix applied there are bitmask values on the lines mentioned above.
I've also checked lines with extension number notation such as:
- https://github.com/bbredesen/go-vk/blob/1.3-main/enum.go#L486
- https://github.com/bbredesen/go-vk/blob/1.3-main/enum.go#L246

After the fix these remain in the old format like they're supposed to.

However there's still at least one mistake with extension-number-like notation I couldn't figure out:
https://github.com/bbredesen/go-vk/blob/1.3-main/enum.go#L730
https://github.com/KhronosGroup/Vulkan-Headers/blob/main/include/vulkan/vulkan_core.h#L14003